### PR TITLE
Added 'repeat' property to emulate 'setIndeterminate:' 

### DIFF
--- a/PCProgressView.h
+++ b/PCProgressView.h
@@ -48,6 +48,9 @@
 /// Specifies the basic duration of the animation, in seconds, defaults to 0.4.
 @property (nonatomic, assign) CFTimeInterval duration;
 
+/// Repeats the animation, works only for animated progress, defaults to NO
+@property (nonatomic, assign) BOOL repeat;
+
 /// Adjusts the current progress shown by the receiver, optionally animating the change.
 - (void)setProgress:(CGFloat)progress animated:(BOOL)animated;
 

--- a/PCProgressView.m
+++ b/PCProgressView.m
@@ -135,6 +135,8 @@
     progress = MIN(progress, 1.0f);
     progress = MAX(progress, 0.0f);
     
+    CGFloat startingProgress = _progress;
+    
     _progress = progress;
     
     CGFloat borderWidth = MAX(self.progressLineWidth, self.backgroundLineWidth);
@@ -161,6 +163,17 @@
     self.currentProgress = _progress;
 
     CGPathRelease(path);
+    
+    if (animated == YES && self.repeat == YES && animationDuration > 1.0)
+    {
+        [self performSelector:@selector(repeat:) withObject:@(startingProgress) afterDelay:animationDuration];
+    }
+}
+
+- (void) repeat:(NSNumber*)startFrom {
+    if (![self superview])return;
+    [self setProgress:startFrom.floatValue animated:NO];
+    [self setProgress:1.0 animated:YES];
 }
 
 


### PR DESCRIPTION
This adds the 'repeat' property to emulate the behaviour of the standard NSProgressIndicator. I.e. once the animation reaches the end, it will go back to the start again. The animation animates between the range that was used for the last setProgress:animated: call. It will also stop once the view has no subview anymore (to allow ARC to pick it up if it's not being used anymore).
